### PR TITLE
Mixin Overhaul v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ buildscript {
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
         mavenCentral()
     }
-    dependencies {
-        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
-    }
 }
 
 plugins {
@@ -95,7 +92,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 repositories {
     mavenLocal()
     maven {
-        url "https://cursemaven.com"
+        url = "https://cursemaven.com"
         content {
             includeGroup "curse.maven"
         }
@@ -112,15 +109,15 @@ repositories {
         }
     }
     maven { // Registrate
-        url "https://maven.tterrag.com/"
+        url = "https://maven.tterrag.com/"
     }
     maven {
         name = "Illusive Soulworks maven"
         url = "https://maven.theillusivec4.top/"
     }
     maven {
-        name "firstdarkdev"
-        url "https://maven.firstdarkdev.xyz/snapshots"
+        name = "firstdarkdev"
+        url = "https://maven.firstdarkdev.xyz/snapshots"
     }
     maven {
         name = "Jared's maven"

--- a/src/main/java/lu/kolja/expandedae/mixin/MixinPlugin.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/MixinPlugin.java
@@ -20,10 +20,12 @@ public class MixinPlugin implements IMixinConfigPlugin {
     public static final Object2ObjectMap<String, String> mixinMap = new Object2ObjectOpenHashMap<>(
         new String[]{
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderLogic",
+                "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderLogicHost",
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderMenu",
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderScreen"
         },
         new String[]{
+                "appflux",
                 "appflux",
                 "appflux",
                 "appflux"

--- a/src/main/java/lu/kolja/expandedae/mixin/MixinPlugin.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/MixinPlugin.java
@@ -22,13 +22,15 @@ public class MixinPlugin implements IMixinConfigPlugin {
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderLogic",
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderLogicHost",
                 "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderMenu",
-                "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderScreen"
+                "lu.kolja.expandedae.mixin.patternprovider.MixinPatternProviderScreen",
+                "lu.kolja.expandedae.mixin.cpu.MixinCraftingCPUCluster"
         },
         new String[]{
                 "appflux",
                 "appflux",
                 "appflux",
-                "appflux"
+                "appflux",
+                "extendedae_plus"
         }
     );
 

--- a/src/main/java/lu/kolja/expandedae/mixin/misc/MixinControllerValidator.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/misc/MixinControllerValidator.java
@@ -3,13 +3,15 @@ package lu.kolja.expandedae.mixin.misc;
 import appeng.blockentity.networking.ControllerBlockEntity;
 import appeng.me.pathfinding.ControllerValidator;
 import java.util.Collection;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import lu.kolja.expandedae.ExpConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(value = ControllerValidator.class, remap = false)
 public abstract class MixinControllerValidator {
@@ -27,14 +29,14 @@ public abstract class MixinControllerValidator {
         return ExpConfig.maxControllerSize;
     }
 
-    @Redirect(
+    @WrapOperation(
             method = "calculateState",
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/me/pathfinding/ControllerValidator;hasControllerCross(Ljava/util/Collection;)Z"
             )
     )
-    private static boolean ignoreControllerRules(Collection<ControllerBlockEntity> controller) {
-        return !ExpConfig.ignoreControllerRules && hasControllerCross(controller);
+    private static boolean ignoreControllerRules(Collection<ControllerBlockEntity> controller, Operation<Boolean> original) {
+        return !ExpConfig.ignoreControllerRules && original.call(controller);
     }
 }

--- a/src/main/java/lu/kolja/expandedae/mixin/misc/MixinSettingToggleButton.java
+++ b/src/main/java/lu/kolja/expandedae/mixin/misc/MixinSettingToggleButton.java
@@ -1,8 +1,6 @@
 package lu.kolja.expandedae.mixin.misc;
 
-import appeng.api.config.CondenserOutput;
 import appeng.api.config.Setting;
-import appeng.api.config.Settings;
 import appeng.client.gui.Icon;
 import appeng.client.gui.widgets.SettingToggleButton;
 import appeng.core.localization.ButtonToolTips;
@@ -10,7 +8,10 @@ import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Predicate;
 
 import static lu.kolja.expandedae.definition.ExpSettings.BLOCKING_MODE;
 import static lu.kolja.expandedae.enums.BlockingMode.*;
@@ -26,18 +27,15 @@ public class MixinSettingToggleButton {
     private static <T extends Enum<T>> void registerApp(Icon icon, Setting<T> setting, T val, ButtonToolTips title,
                                                         Component... tooltipLines) {}
 
-    @Redirect(method = "<init>(Lappeng/api/config/Setting;Ljava/lang/Enum;Ljava/util/function/Predicate;Lappeng/client/gui/widgets/SettingToggleButton$IHandler;)V",
+    @Inject(
+            method = "<init>(Lappeng/api/config/Setting;Ljava/lang/Enum;Ljava/util/function/Predicate;Lappeng/client/gui/widgets/SettingToggleButton$IHandler;)V",
             at = @At(value = "INVOKE",
                     target = "Lappeng/client/gui/widgets/SettingToggleButton;registerApp(Lappeng/client/gui/Icon;Lappeng/api/config/Setting;Ljava/lang/Enum;Lappeng/core/localization/ButtonToolTips;Lappeng/core/localization/ButtonToolTips;)V",
-                    ordinal = 0),
-            remap = false)
-    private <T extends Enum<T>> void register(Icon icon, Setting<T> setting, T val, ButtonToolTips title,
-                                              ButtonToolTips hint) {
-
-        registerApp(Icon.CONDENSER_OUTPUT_TRASH, Settings.CONDENSER_OUTPUT, CondenserOutput.TRASH,
-                ButtonToolTips.CondenserOutput,
-                ButtonToolTips.Trash);
-
+                    ordinal = 0,
+                    shift = At.Shift.AFTER
+            )
+    )
+    private <T extends Enum<T>> void register(Setting<T> setting, T val, Predicate<T> isValidValue, SettingToggleButton.IHandler<SettingToggleButton<T>> onPress, CallbackInfo ci) {
         registerApp(Icon.CLEAR, BLOCKING_MODE, ALL,
                 ButtonToolTips.InterfaceBlockingMode,
                 Component.translatable("gui.expandedae.blocking_mode.all")


### PR DESCRIPTION
Another attempt at optimizing some mixins.

These are only the changes that would have worked from the last PR anyways.
- build script cleanup
- mod compatibility with AppFlux and ExtendedAE Plus
- mixin optimizations: Removed 2 Redirects which are really more 1 Inject and 1 WrapOperation.

#####

As I mentioned in a comment on the (closed) last PR, there is still one overwrite in place. It doesn't cause an issue (as far as I could tell with the mods I tested with), so I didn't spend too much time investigating how to get rid of that as well.

I kinda also want to return to mixing into the TargetCache instead of fully replacing it, but I'm not sure how to do that currently, as the decision logic for the blocking feature got moved there and needs the ConfigManager which you added in your own copy of it. I have an idea on how to handle that by basically writing that with a setter instead, but it's not completely perfect, so if I ever get around to working on that, I'll do it in a separate PR. I think that this change would also indirectly get rid of the overwrite, so that'd be neat.

Feedback welcome!